### PR TITLE
Inserted Time dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,12 @@
   {
     "type": "git",
     "url": "https://github.com/JChristensen/DS3232RTC.git"
-  },
+  }, 
+  "dependencies": {
+      "name": "Time", 
+      "authors": "Paul Stoffregen", 
+      "frameworks": "arduino"
+  }, 
   "frameworks": "arduino",
   "platforms": "atmelavr"
 }


### PR DESCRIPTION
With the declaration of this in the dependencies section, the Time library will be installed automatically.
Check DallasTemperature library, which depends on OneWire library, for a good example.
https://platformio.org/lib/show/54/DallasTemperature/manifest